### PR TITLE
Add methods for rendering on worker thread

### DIFF
--- a/HeatMapLib/build.gradle
+++ b/HeatMapLib/build.gradle
@@ -22,6 +22,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
+    compile 'com.android.support:support-annotations:24.2.1'
 }
 
 apply plugin: 'com.github.dcendents.android-maven'


### PR DESCRIPTION
Hi there! Thanks for creating this library, much appreciated!

While giving this lib a whirl, I noticed that rendering the heatmap is quite an expensive operation to perform on the UI thread. Drawing ~100 data points took 300ms or so on my Nexus 5X, and caused a noticeable pause in the incoming transition of a fragment I used it in. I profiled this, and most of the time is spent in `Canvas.native_drawCircle` calls downstack of `tryRefresh`.

This PR adds a method `forceRefreshOnWorkerThread` to the heatmap class, which works similar to `forceRefresh` but is intended to be called on a worker thread. Internally, it calls `tryRefresh` and takes care of most of the expensive operations.

There are also a bunch of annotations, to support setting up a heatmap in a worker thread without getting "wrong thread" errors all over.

I tested this and the UI where I noticed this problem runs smoothly now. I also profiled before and after, the operations are properly run in the background thread now.